### PR TITLE
Bug1002338: Check mFilledBuffers before filling output buffers.

### DIFF
--- a/media/libstagefright/OMXCodec.cpp
+++ b/media/libstagefright/OMXCodec.cpp
@@ -2753,6 +2753,9 @@ status_t OMXCodec::freeBuffersOnPort(
     }
 
     CHECK(onlyThoseWeOwn || buffers->isEmpty());
+    if (portIndex == kPortIndexOutput) {
+        mFilledBuffers.clear();
+    }
 
     return stickyErr;
 }
@@ -2882,9 +2885,16 @@ void OMXCodec::fillOutputBuffers() {
     }
 
     Vector<BufferInfo> *buffers = &mPortBuffers[kPortIndexOutput];
+    Vector<bool> buffersFilled;
+    for (size_t i = 0; i < buffers->size(); ++i) {
+        buffersFilled.push_back(false);
+    }
+    for (List<size_t>::iterator it = mFilledBuffers.begin(); it != mFilledBuffers.end(); ++it) {
+        buffersFilled.editItemAt(*it) = true;
+    }
     for (size_t i = 0; i < buffers->size(); ++i) {
         BufferInfo *info = &buffers->editItemAt(i);
-        if (info->mStatus == OWNED_BY_US) {
+        if (!buffersFilled[i] && info->mStatus == OWNED_BY_US) {
             fillOutputBuffer(&buffers->editItemAt(i));
         }
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1002338

If BufferInfo::mStatus of one BufferInfo in OMXCode::mPortBuffers[kPortIndexOutput] is OWNED_BY_US, that means this BufferInfo is either an unused empty buffer hold by OMXCodec, or a ready-to-be-retrieved buffer filled with decoded data hold by OMXCodec.

In OMXCodec::fillOutputBuffers(), all BufferInfos with OWNED_BY_US status are sent to the underlying component for being filled with decoded data in the future.

However, OMXCodec should check whether BufferInfo contains decoded data already or not before sending it to the underlying component.

ref: https://bugzilla.mozilla.org/show_bug.cgi?id=990908#c19
ref: https://bug990908.bugzilla.mozilla.org/attachment.cgi?id=8407471
