### PR TITLE
Bug 1009410 - Expose graphic Buffer to MediaCodec

### DIFF
--- a/include/media/stagefright/ACodec.h
+++ b/include/media/stagefright/ACodec.h
@@ -84,6 +84,8 @@ struct ACodec : public AHierarchicalStateMachine {
         DISALLOW_EVIL_CONSTRUCTORS(PortDescription);
     };
 
+friend class MediaCodec;
+
 protected:
     virtual ~ACodec();
 
@@ -194,6 +196,8 @@ private:
 
     bool mChannelMaskPresent;
     int32_t mChannelMask;
+
+    bool mUseUndequeuedBufs;
 
     status_t setCyclicIntraMacroblockRefresh(const sp<AMessage> &msg, int32_t mode);
     status_t allocateBuffersOnPort(OMX_U32 portIndex);

--- a/include/media/stagefright/MediaCodec.h
+++ b/include/media/stagefright/MediaCodec.h
@@ -121,6 +121,10 @@ struct MediaCodec : public AHandler {
 
     status_t setParameters(const sp<AMessage> &params);
 
+    // This is used to get graphicBuffer with the index obtained from
+    // calling dequeueOutputBuffer()
+    sp<GraphicBuffer> getOutputGraphicBufferFromIndex(size_t index);
+
 protected:
     virtual ~MediaCodec();
     virtual void onMessageReceived(const sp<AMessage> &msg);

--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -363,7 +363,8 @@ ACodec::ACodec()
       mEncoderDelay(0),
       mEncoderPadding(0),
       mChannelMaskPresent(false),
-      mChannelMask(0) {
+      mChannelMask(0),
+      mUseUndequeuedBufs(false) {
     mUninitializedState = new UninitializedState(this);
     mLoadedState = new LoadedState(this);
     mLoadedToIdleState = new LoadedToIdleState(this);
@@ -678,7 +679,11 @@ status_t ACodec::allocateOutputBuffersFromNativeWindow() {
         cancelEnd = mBuffers[kPortIndexOutput].size();
     } else {
         // Return the last two buffers to the native window.
-        cancelStart = def.nBufferCountActual - minUndequeuedBufs;
+        if (mUseUndequeuedBufs) {
+          cancelStart = def.nBufferCountActual;
+        } else {
+          cancelStart = def.nBufferCountActual - minUndequeuedBufs;
+        }
         cancelEnd = def.nBufferCountActual;
     }
 
@@ -1065,6 +1070,13 @@ status_t ACodec::configureCodec(
         err = setMinBufferSize(kPortIndexInput, (size_t)maxInputSize);
     } else if (!strcmp("OMX.Nvidia.aac.decoder", mComponentName.c_str())) {
         err = setMinBufferSize(kPortIndexInput, 8192);  // XXX
+    }
+
+    int32_t useUndequeuedBufs;
+    if (msg->findInt32("moz-use-undequeued-bufs", &useUndequeuedBufs)) {
+        mUseUndequeuedBufs = true;
+    } else {
+        mUseUndequeuedBufs = false;
     }
 
     return err;

--- a/media/libstagefright/MediaCodec.cpp
+++ b/media/libstagefright/MediaCodec.cpp
@@ -1794,4 +1794,13 @@ status_t MediaCodec::amendOutputFormatWithCodecSpecificData(
     return OK;
 }
 
+sp<GraphicBuffer> MediaCodec::getOutputGraphicBufferFromIndex(size_t index) {
+
+    if (mState != STARTED || index >= mPortBuffers[kPortIndexOutput].size()) {
+        return NULL;
+    }
+
+    return mCodec->mBuffers[kPortIndexOutput].editItemAt(index).mGraphicBuffer;
+}
+
 }  // namespace android


### PR DESCRIPTION
Since current B2G render pipeline needs graphicBuffer and MediaCodec cannot get graphicBuffer, we need to modify MediaCodec and ACodec to expose it.
More info is on https://bugzilla.mozilla.org/show_bug.cgi?id=1009410. 
