### PR TITLE
Bug 1114477 - Stop source after thread stopped. r=mikeh

### DIFF
--- a/media/libstagefright/MPEG4Writer.cpp
+++ b/media/libstagefright/MPEG4Writer.cpp
@@ -1783,13 +1783,16 @@ status_t MPEG4Writer::Track::stop() {
     }
     mDone = true;
 
-    ALOGD("%s track source stopping", mIsAudio? "Audio": "Video");
-    mSource->stop();
-    ALOGD("%s track source stopped", mIsAudio? "Audio": "Video");
-
     void *dummy;
     pthread_join(mThread, &dummy);
     status_t err = static_cast<status_t>(reinterpret_cast<uintptr_t>(dummy));
+    ALOGD("Stopping %s track source", mIsAudio? "Audio": "Video");
+    {
+        status_t status = mSource->stop();
+        if (err == OK && status != OK && status != ERROR_END_OF_STREAM) {
+            err = status;
+        }
+    }
 
     ALOGD("%s track stopped", mIsAudio? "Audio": "Video");
     return err;


### PR DESCRIPTION
There're chances that writer thread will wait for  filled buffer forever if its source (OMXCodec) stopped first.
