### PR TITLE
Bug919590 - Change OMXCodec::pause() to support b2g

### DIFF
--- a/media/libstagefright/OMXCodec.cpp
+++ b/media/libstagefright/OMXCodec.cpp
@@ -4654,11 +4654,8 @@ void OMXCodec::initOutputFormat(const sp<MetaData> &inputFormat) {
 }
 
 status_t OMXCodec::pause() {
-    Mutex::Autolock autoLock(mLock);
-
-    mPaused = true;
-
-    return OK;
+    // b2g does not support aosp OMXCodec::pause(). See Bug 919590.
+    return ERROR_UNSUPPORTED;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Cherry-picking https://github.com/mozilla-b2g/platform_frameworks_av/commit/ee814270f52127febfcf29bacf9f1b327d7c4c29
