### PR TITLE
Bug 1120332 - Replace getService() with checkService(). r=sotaro

### DIFF
--- a/media/libstagefright/MediaCodec.cpp
+++ b/media/libstagefright/MediaCodec.cpp
@@ -67,7 +67,7 @@ MediaCodec::BatteryNotifier::BatteryNotifier() :
     const sp<IServiceManager> sm(defaultServiceManager());
     if (sm != NULL) {
         const String16 name("batterystats");
-        mBatteryStatService = interface_cast<IBatteryStats>(sm->getService(name));
+        mBatteryStatService = interface_cast<IBatteryStats>(sm->checkService(name));
         if (mBatteryStatService == NULL) {
             ALOGE("batterystats service unavailable!");
         }


### PR DESCRIPTION
B2G doesn't have 'batterystats' service. Use checkService() to return immediately rather than waiting for 5 seconds in getService().
