### PR TITLE
 Bug 1120780 - Video recording blocking in drawImage

### DIFF
--- a/include/media/stagefright/ColorConverter.h
+++ b/include/media/stagefright/ColorConverter.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include <utils/Errors.h>
+#include <media/editor/II420ColorConverter.h>
 
 #include <OMX_Video.h>
 
@@ -60,6 +61,8 @@ private:
     };
 
     OMX_COLOR_FORMATTYPE mSrcFormat, mDstFormat;
+    void *mI420Handle;
+    II420ColorConverter mI420Converter;
     uint8_t *mClip;
 
     uint8_t *initClip();
@@ -103,6 +106,11 @@ private:
             const void *srcBits, size_t srcSkip,
             void *dstBits, size_t dstSkip,
             size_t alignedWidth);
+
+    status_t convertQCOMYUV420SemiPlanarVenus(
+            const BitmapParams &src, const BitmapParams &dst);
+
+    status_t loadI420Converter();
 
     ColorConverter(const ColorConverter &);
     ColorConverter &operator=(const ColorConverter &);


### PR DESCRIPTION
 cherry pick from kk branch

 Author: Diego Wilson dwilson@codeaurora.org
 Date:   Wed Nov 27 07:21:33 2013 -0800

```
Support conversion from YUV Venus to RGB 565

YUV Venus is the format of OMX video frames. It needs to be
converted to RGB 565 when generating video clip thumbnails
```
