### PR TITLE
Revert "libstagefright: Do not offload HEVC AV decoding"

### DIFF
--- a/include/media/stagefright/Utils.h
+++ b/include/media/stagefright/Utils.h
@@ -60,7 +60,7 @@ void mapAACProfileToAudioFormat(audio_format_t& format, uint64_t eAacProfile);
 status_t sendMetaDataToHal(sp<MediaPlayerBase::AudioSink>& sink, const sp<MetaData>& meta);
 
 // Check whether the stream defined by meta can be offloaded to hardware
-bool canOffloadStream(const sp<MetaData>& meta, bool hasVideo, const sp<MetaData>& vMeta,
+bool canOffloadStream(const sp<MetaData>& meta, bool hasVideo,
                       bool isStreaming, audio_stream_type_t streamType);
 void printFileName(int fd);
 

--- a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
@@ -645,15 +645,13 @@ void NuPlayer::onMessageReceived(const sp<AMessage> &msg) {
             }
 
             sp<AMessage> videoFormat = mSource->getFormat(false /* audio */);
-            sp<MetaData> vMeta = new MetaData;
-            convertMessageToMetaData(videoFormat, vMeta);
 
             const char *mime = NULL;
             if (audioMeta != NULL) {
                 audioMeta->findCString(kKeyMIMEType, &mime);
             }
             mOffloadAudio =
-                        canOffloadStream(audioMeta, (videoFormat != NULL), vMeta,
+                        canOffloadStream(audioMeta, (videoFormat != NULL),
                                 mIsStreaming /* is_streaming */, streamType);
             if (!mOffloadAudio && (audioMeta != NULL)) {
                 sp<MetaData> audioSourceMeta = mSource->getFormatMeta(true/* audio */);
@@ -662,7 +660,7 @@ void NuPlayer::onMessageReceived(const sp<AMessage> &msg) {
 
                 mOffloadAudio =
                         ((mime && !ExtendedUtils::pcmOffloadException(mime)) &&
-                        canOffloadStream(audioPCMMeta, (videoFormat != NULL), vMeta,
+                        canOffloadStream(audioPCMMeta, (videoFormat != NULL),
                                 mIsStreaming /* is_streaming */, streamType));
                 mOffloadDecodedPCM = mOffloadAudio;
                 ALOGI("Could not offload audio decode, pcm offload decided :%d",

--- a/media/libstagefright/AwesomePlayer.cpp
+++ b/media/libstagefright/AwesomePlayer.cpp
@@ -1688,11 +1688,7 @@ status_t AwesomePlayer::initAudioDecoder() {
     ATRACE_CALL();
 
     sp<MetaData> meta = mAudioTrack->getFormat();
-    sp<MetaData> vMeta;
     status_t err;
-    if (mVideoTrack != NULL && mVideoSource != NULL) {
-        vMeta = mVideoTrack->getFormat();
-    }
 
     const char *mime;
     CHECK(meta->findCString(kKeyMIMEType, &mime));
@@ -1705,7 +1701,7 @@ status_t AwesomePlayer::initAudioDecoder() {
         streamType = mAudioSink->getAudioStreamType();
     }
 
-    mOffloadAudio = canOffloadStream(meta, (mVideoSource != NULL), vMeta,
+    mOffloadAudio = canOffloadStream(meta, (mVideoSource != NULL),
                                      (isStreamingHTTP() || isWidevineContent()),
                                      streamType);
 
@@ -1744,7 +1740,7 @@ status_t AwesomePlayer::initAudioDecoder() {
         if (durationUs >= 0) {
             format->setInt64(kKeyDuration, durationUs);
         }
-        mOffloadAudio = canOffloadStream(format, (mVideoSource != NULL), vMeta,
+        mOffloadAudio = canOffloadStream(format, (mVideoSource != NULL),
                                      (isStreamingHTTP() || isWidevineContent()), streamType);
     }
 

--- a/media/libstagefright/Utils.cpp
+++ b/media/libstagefright/Utils.cpp
@@ -767,7 +767,7 @@ const struct aac_format_conv_t* p = &profileLookup[0];
     return;
 }
 
-bool canOffloadStream(const sp<MetaData>& meta, bool hasVideo, const sp<MetaData>& vMeta,
+bool canOffloadStream(const sp<MetaData>& meta, bool hasVideo,
                       bool isStreaming, audio_stream_type_t streamType)
 {
     const char *mime;
@@ -775,17 +775,6 @@ bool canOffloadStream(const sp<MetaData>& meta, bool hasVideo, const sp<MetaData
         return false;
     }
     CHECK(meta->findCString(kKeyMIMEType, &mime));
-
-    if (hasVideo) {
-        const char *vMime;
-        CHECK(vMeta->findCString(kKeyMIMEType, &vMime));
-#ifdef ENABLE_AV_ENHANCEMENTS
-        if (!strncmp(vMime, MEDIA_MIMETYPE_VIDEO_HEVC, strlen(MEDIA_MIMETYPE_VIDEO_HEVC))) {
-            ALOGD("Do not offload HEVC audio+video playback");
-            return false;
-        }
-#endif
-    }
 
     audio_offload_info_t info = AUDIO_INFO_INITIALIZER;
 


### PR DESCRIPTION
Gecko uses AOSP's canOffloadStream() with 4 parameters, so we should revert the commit for CAF version.
Refer the commit: https://www.codeaurora.org/cgit/quic/la/platform/frameworks/av/commit/?h=LF.BR.1.2.3&id=a4b9ff7252272cedff593937e8e6dab842bd4209
