### PR TITLE
Bug 1226135 - use all allocated meta output buffers when decoder is c…

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -799,7 +799,12 @@ status_t ACodec::allocateOutputMetaDataBuffers() {
              mComponentName.c_str(), info.mBufferID, mem->pointer());
     }
 
-    mMetaDataBuffersToSubmit = bufferCount - minUndequeuedBuffers;
+    if (mUseUndequeuedBufs) {
+        // Use all allocated buffers.
+        mMetaDataBuffersToSubmit = bufferCount;
+    } else {
+        mMetaDataBuffersToSubmit = bufferCount - minUndequeuedBuffers;
+    }
     return err;
 }
 


### PR DESCRIPTION
Similar to https://github.com/mozilla-b2g/platform_frameworks_av/commit/de3145b279dd897c1805b3c6ef994e68c9a6faf1#diff-cdd7e40ab80554dbedbbb838ebd4bde0L750 but for meta output buffers.
