### PR TITLE
Bug 1148049: Correct the SoftMP3's silence frames and timestamp.

### DIFF
--- a/media/libstagefright/codecs/mp3dec/SoftMP3.cpp
+++ b/media/libstagefright/codecs/mp3dec/SoftMP3.cpp
@@ -282,24 +282,18 @@ void SoftMP3::onQueueFilled(OMX_U32 portIndex) {
             return;
         }
 
+        outHeader->nOffset = 0;
+        outHeader->nFilledLen = mConfig->outputFrameSize * sizeof(int16_t);
+        outHeader->nTimeStamp =
+            mAnchorTimeUs
+                + (mNumFramesOutput * 1000000ll) / mConfig->samplingRate;
         if (mIsFirst) {
             mIsFirst = false;
             // The decoder delay is 529 samples, so trim that many samples off
             // the start of the first output buffer. This essentially makes this
             // decoder have zero delay, which the rest of the pipeline assumes.
-            outHeader->nOffset =
-                kPVMP3DecoderDelay * mNumChannels * sizeof(int16_t);
-
-            outHeader->nFilledLen =
-                mConfig->outputFrameSize * sizeof(int16_t) - outHeader->nOffset;
-        } else if (!mSignalledOutputEos) {
-            outHeader->nOffset = 0;
-            outHeader->nFilledLen = mConfig->outputFrameSize * sizeof(int16_t);
+            memset(outHeader->pBuffer, 0, kPVMP3DecoderDelay * mNumChannels * sizeof(int16_t));
         }
-
-        outHeader->nTimeStamp =
-            mAnchorTimeUs
-                + (mNumFramesOutput * 1000000ll) / mConfig->samplingRate;
 
         if (inHeader) {
             CHECK_GE(inHeader->nFilledLen, mConfig->inputBufferUsedLength);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1148049
comment 37.
